### PR TITLE
Moving results call within condition block to prevent an indexerror i…

### DIFF
--- a/wharton_cosign_auth/remote_user.py
+++ b/wharton_cosign_auth/remote_user.py
@@ -9,8 +9,8 @@ class WhartonRemoteUserBackend(RemoteUserBackend):
     def configure_user(self, user):
         response = call_wisp_api(
             'https://apps.wharton.upenn.edu/wisp/api/v1/adusers', {'username': user.username})
-        results = response['results'][0]
-        if results:
+        if response:
+            results = response['results'][0]
             user.first_name = results['first_name']
             user.last_name = results['last_name']
             user.email = results['email'].replace('exchange.', '')

--- a/wharton_cosign_auth/remote_user.py
+++ b/wharton_cosign_auth/remote_user.py
@@ -9,7 +9,7 @@ class WhartonRemoteUserBackend(RemoteUserBackend):
     def configure_user(self, user):
         response = call_wisp_api(
             'https://apps.wharton.upenn.edu/wisp/api/v1/adusers', {'username': user.username})
-        if response:
+        if response['results']:
             results = response['results'][0]
             user.first_name = results['first_name']
             user.last_name = results['last_name']


### PR DESCRIPTION
- Moving results call within condition block to prevent an indexerror if results are empty.
- Leaving PermissionDenied  as is for verbosity and clarity. We still cannot throw an django exception here and will have to catch it further down as an anonymous user
