### PR TITLE
Always return a user and let the app handle authorization

### DIFF
--- a/wharton_cosign_auth/remote_user.py
+++ b/wharton_cosign_auth/remote_user.py
@@ -1,5 +1,4 @@
 from django.contrib.auth.backends import RemoteUserBackend
-from django.core.exceptions import PermissionDenied
 
 from wharton_cosign_auth.utilities import call_wisp_api
 
@@ -26,6 +25,6 @@ class WhartonRemoteUserBackend(RemoteUserBackend):
         else:
             '''
             Even though someone can login with Pennkey, there is a chance
-            the user is not a Wharton user; in this case, raise a PermissionDenied
+            the user is not a Wharton user; in this case, just return the user object since raising a PermissionDenied doesn't do anything and let the app control the access
             '''
-            raise PermissionDenied
+            return user


### PR DESCRIPTION
Throwing a permission denied error doesn't do anything so we should just return the user from the configure method and then let the app handle authorization.